### PR TITLE
Allow demultiplex file using FASTQ

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -195,7 +195,7 @@ process QC_fastq {
 
   script:
   """
-  seqkit fx2tab -j $task.cpus -q --gc -l -H -n $sampleFASTQ |\
+  seqkit fx2tab -j $task.cpus -q --gc -l -H -n -i $sampleFASTQ |\
     csvtk mutate2 -C '%' -t -n sample -e '"${sampleID}"' > ${sampleID}.seqkit.readstats.tsv
   seqkit stats -T -j $task.cpus -a ${sampleFASTQ} |\
     csvtk mutate2 -C '%' -t -n sample -e '"${sampleID}"' > ${sampleID}.seqkit.summarystats.tsv


### PR DESCRIPTION
Added `-i` to `seqkit` in case of users demultiplexing from FASTQ instead of BAM (which is then converted into FASTQ). Reason is that the FASTQ header may contain a lot of ASCII characters causing issue with csvtk. `-i` will keep just the ZMW ID.